### PR TITLE
Ensure correct timezone is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,13 @@ workflows:
   quality-tools:
     jobs:
       - unit-tests:
-          context: Generic
+          context: Dummy
       - acceptance-tests:
-          context: Generic
+          context: Dummy
       - phpstan:
-          context: Generic
+          context: Dummy
       - phpcs:
-          context: Generic
+          context: Dummy
 
 jobs:
   unit-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,13 @@ workflows:
   quality-tools:
     jobs:
       - unit-tests:
-          context: Dummy
+          context: Generic
       - acceptance-tests:
-          context: Dummy
+          context: Generic
       - phpstan:
-          context: Dummy
+          context: Generic
       - phpcs:
-          context: Dummy
+          context: Generic
 
 jobs:
   unit-tests:

--- a/docker/Dockerfile-php
+++ b/docker/Dockerfile-php
@@ -1,7 +1,7 @@
 FROM php:7.2.2-cli
 
 RUN apt-get update \
-    && apt-get install libzip-dev unzip
+    && apt-get -y install libzip-dev unzip
 
 
 RUN pecl install xdebug-2.6.0 zip \

--- a/docker/Dockerfile-php
+++ b/docker/Dockerfile-php
@@ -1,4 +1,8 @@
 FROM php:7.2.2-cli
 
-RUN pecl install xdebug-2.6.0 \
-    && docker-php-ext-enable xdebug
+RUN apt-get update \
+    && apt-get install libzip-dev unzip
+
+
+RUN pecl install xdebug-2.6.0 zip \
+    && docker-php-ext-enable xdebug zip

--- a/src/Message/Timestamp.php
+++ b/src/Message/Timestamp.php
@@ -15,8 +15,8 @@ final class Timestamp extends DateTimeImmutable implements JsonSerializable
 
     public function __toString(): string
     {
-        $me = clone $this;
+        $utc = $this->setTimezone(new \DateTimeZone('UTC'));
 
-        return $me->format('Y-m-d\TH:i:s.u\Z');
+        return $utc->format('Y-m-d\TH:i:s.u\Z');
     }
 }

--- a/tests/Unit/Message/TimestampTest.php
+++ b/tests/Unit/Message/TimestampTest.php
@@ -5,8 +5,8 @@ namespace TechDeCo\ElasticApmAgent\Tests\Unit\Message;
 
 use PHPUnit\Framework\TestCase;
 use TechDeCo\ElasticApmAgent\Message\Timestamp;
-use function \date_default_timezone_get;
-use function \date_default_timezone_set;
+use function date_default_timezone_get;
+use function date_default_timezone_set;
 
 final class TimestampTest extends TestCase
 {

--- a/tests/Unit/Message/TimestampTest.php
+++ b/tests/Unit/Message/TimestampTest.php
@@ -5,6 +5,8 @@ namespace TechDeCo\ElasticApmAgent\Tests\Unit\Message;
 
 use PHPUnit\Framework\TestCase;
 use TechDeCo\ElasticApmAgent\Message\Timestamp;
+use function \date_default_timezone_get;
+use function \date_default_timezone_set;
 
 final class TimestampTest extends TestCase
 {
@@ -16,12 +18,12 @@ final class TimestampTest extends TestCase
 
     public function setUp(): void
     {
-        $this->oldTimeZone = \date_default_timezone_get();
+        $this->oldTimeZone = date_default_timezone_get();
     }
 
     public function testWithUtc(): void
     {
-        \date_default_timezone_set('UTC');
+        date_default_timezone_set('UTC');
         $date = new Timestamp('2018-01-15 12:00');
 
         self::assertEquals('2018-01-15T12:00:00.000000Z', $date->jsonSerialize());
@@ -29,7 +31,7 @@ final class TimestampTest extends TestCase
 
     public function testWithOtherTimezone(): void
     {
-        \date_default_timezone_set('Asia/Tokyo');
+        date_default_timezone_set('Asia/Tokyo');
         $date = new Timestamp('2018-01-15 12:00');
 
         self::assertEquals('2018-01-15T03:00:00.000000Z', $date->jsonSerialize());
@@ -37,6 +39,6 @@ final class TimestampTest extends TestCase
 
     public function tearDown(): void
     {
-        \date_default_timezone_set($this->oldTimeZone);
+        date_default_timezone_set($this->oldTimeZone);
     }
 }

--- a/tests/Unit/Message/TimestampTest.php
+++ b/tests/Unit/Message/TimestampTest.php
@@ -8,10 +8,35 @@ use TechDeCo\ElasticApmAgent\Message\Timestamp;
 
 final class TimestampTest extends TestCase
 {
+    /**
+     * Used to restore correct timezone after switching to different ones during tests.
+     * @var $oldTimeZone string
+     */
+    private $oldTimeZone;
+
+    public function setUp()
+    {
+        $this->oldTimeZone = date_default_timezone_get();
+    }
+
     public function testWithUtc(): void
     {
+        date_default_timezone_set('UTC');
         $date = new Timestamp('2018-01-15 12:00');
 
         self::assertEquals('2018-01-15T12:00:00.000000Z', $date->jsonSerialize());
+    }
+
+    public function testWithOtherTimezone(): void
+    {
+        date_default_timezone_set('Asia/Tokyo');
+        $date = new Timestamp('2018-01-15 12:00');
+
+        self::assertEquals('2018-01-15T03:00:00.000000Z', $date->jsonSerialize());
+    }
+
+    public function tearDown()
+    {
+        date_default_timezone_set($this->oldTimeZone);
     }
 }

--- a/tests/Unit/Message/TimestampTest.php
+++ b/tests/Unit/Message/TimestampTest.php
@@ -14,14 +14,14 @@ final class TimestampTest extends TestCase
      */
     private $oldTimeZone;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->oldTimeZone = date_default_timezone_get();
+        $this->oldTimeZone = \date_default_timezone_get();
     }
 
     public function testWithUtc(): void
     {
-        date_default_timezone_set('UTC');
+        \date_default_timezone_set('UTC');
         $date = new Timestamp('2018-01-15 12:00');
 
         self::assertEquals('2018-01-15T12:00:00.000000Z', $date->jsonSerialize());
@@ -29,14 +29,14 @@ final class TimestampTest extends TestCase
 
     public function testWithOtherTimezone(): void
     {
-        date_default_timezone_set('Asia/Tokyo');
+        \date_default_timezone_set('Asia/Tokyo');
         $date = new Timestamp('2018-01-15 12:00');
 
         self::assertEquals('2018-01-15T03:00:00.000000Z', $date->jsonSerialize());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        date_default_timezone_set($this->oldTimeZone);
+        \date_default_timezone_set($this->oldTimeZone);
     }
 }


### PR DESCRIPTION
If PHP does not use UTC timezone, the timestamps sent are wrong.
Converted `Timestamp` to UTC timezone during serialization to ensure that the timestamps sent to APM are correct.

## Description
Sending timestamp `2018-01-15T12:00:00.000000Z` to APM API means that the event happened at midday in UTC timezone, as per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
Therefore if PHP is not using UTC the timestamp must be converted before sending it.
