### PR TITLE
Timezones must be converted to UTC

### DIFF
--- a/src/Message/Timestamp.php
+++ b/src/Message/Timestamp.php
@@ -15,8 +15,8 @@ final class Timestamp extends DateTimeImmutable implements JsonSerializable
 
     public function __toString(): string
     {
-        $me = clone $this;
+        $utc = $this->setTimezone(new \DateTimeZone('UTC'));
 
-        return $me->format('Y-m-d\TH:i:s.u\Z');
+        return $utc->format('Y-m-d\TH:i:s.u\Z');
     }
 }

--- a/tests/Unit/Message/TimestampTest.php
+++ b/tests/Unit/Message/TimestampTest.php
@@ -5,13 +5,42 @@ namespace TechDeCo\ElasticApmAgent\Tests\Unit\Message;
 
 use PHPUnit\Framework\TestCase;
 use TechDeCo\ElasticApmAgent\Message\Timestamp;
+use function date_default_timezone_get;
+use function date_default_timezone_set;
 
 final class TimestampTest extends TestCase
 {
+    /**
+     * Used to restore correct timezone after switching to different ones during tests.
+     * @var string $oldTimeZone
+     */
+    private $oldTimeZone;
+
+    public function setUp(): void
+    {
+        $this->oldTimeZone = date_default_timezone_get();
+    }
+
     public function testWithUtc(): void
     {
+        date_default_timezone_set('UTC');
         $date = new Timestamp('2018-01-15 12:00');
 
         self::assertEquals('2018-01-15T12:00:00.000000Z', $date->jsonSerialize());
+    }
+
+    public function testWithOtherTimeZone(): void
+    {
+        /* Use Tokyo because Japan has no daylight saving time */
+        date_default_timezone_set('Asia/Tokyo');
+        $date = new Timestamp('2018-01-15 12:00');
+
+        self::assertEquals('2018-01-15T03:00:00.000000Z', $date->jsonSerialize());
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        date_default_timezone_set($this->oldTimeZone);
     }
 }

--- a/tests/Unit/Request/ErrorTest.php
+++ b/tests/Unit/Request/ErrorTest.php
@@ -22,6 +22,7 @@ final class ErrorTest extends TestCase
         $process = new Process(213);
         $system  = (new System())->atHost('hades');
         $date    = new Timestamp('2018-02-14T10:11:12.131');
+        $utcDate = (clone $date)->setTimezone(new \DateTimeZone('UTC'));
         $log     = new Log('blabla');
         $message = ErrorMessage::fromLog($log, $date);
 
@@ -43,7 +44,7 @@ final class ErrorTest extends TestCase
             'errors' => [
                 [
                     'log' => ['message' => 'blabla'],
-                    'timestamp' => '2018-02-14T10:11:12.131000Z',
+                    'timestamp' => $utcDate->format('Y-m-d\TH:i:s.u\Z'),
                 ],
             ],
         ];
@@ -56,6 +57,7 @@ final class ErrorTest extends TestCase
         $agent   = new VersionedName('thunderjaw', '1.0');
         $service = new Service($agent, 'rockbreaker');
         $date    = new Timestamp('2018-02-14T10:11:12.131');
+        $utcDate = (clone $date)->setTimezone(new \DateTimeZone('UTC'));
         $log     = new Log('blabla');
         $message = ErrorMessage::fromLog($log, $date);
 
@@ -73,7 +75,7 @@ final class ErrorTest extends TestCase
             'errors' => [
                 [
                     'log' => ['message' => 'blabla'],
-                    'timestamp' => '2018-02-14T10:11:12.131000Z',
+                    'timestamp' => $utcDate->format('Y-m-d\TH:i:s.u\Z'),
                 ],
             ],
         ];

--- a/tests/Unit/Request/TransactionTest.php
+++ b/tests/Unit/Request/TransactionTest.php
@@ -19,6 +19,7 @@ final class TransactionTest extends TestCase
     {
         $id      = Uuid::uuid4();
         $date    = new Timestamp('2018-02-14T10:11:12.131');
+        $utcDate = (clone $date)->setTimezone(new \DateTimeZone('UTC'));
         $message = (new TransactionMessage(13.2, $id, 'alloy', $date, 'zeta'));
         $agent   = new VersionedName('thunderjaw', '1.0');
         $service = new Service($agent, 'rockbreaker');
@@ -45,7 +46,7 @@ final class TransactionTest extends TestCase
                     'duration' => 13.2,
                     'id' => $id->toString(),
                     'name' => 'alloy',
-                    'timestamp' => '2018-02-14T10:11:12.131000Z',
+                    'timestamp' => $utcDate->format('Y-m-d\TH:i:s.u\Z'),
                     'type' => 'zeta',
                 ],
             ],
@@ -58,6 +59,7 @@ final class TransactionTest extends TestCase
     {
         $id      = Uuid::uuid4();
         $date    = new Timestamp('2018-02-14T10:11:12.131');
+        $utcDate = (clone $date)->setTimezone(new \DateTimeZone('UTC'));
         $message = (new TransactionMessage(13.2, $id, 'alloy', $date, 'zeta'));
         $agent   = new VersionedName('thunderjaw', '1.0');
         $service = new Service($agent, 'rockbreaker');
@@ -78,7 +80,7 @@ final class TransactionTest extends TestCase
                     'duration' => 13.2,
                     'id' => $id->toString(),
                     'name' => 'alloy',
-                    'timestamp' => '2018-02-14T10:11:12.131000Z',
+                    'timestamp' => $utcDate->format('Y-m-d\TH:i:s.u\Z'),
                     'type' => 'zeta',
                 ],
             ],


### PR DESCRIPTION
Convert all timestamps to UTC

## Description
Elastic APM expects all timestamps to be formatted in UTC timezone.
This is represented by the leading `Z` in Timestamp JSON schema:
```
        "timestamp": {
            "type": ["string", "null"],
            "pattern": "Z$",
            "format": "date-time",
            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
        },
```
as per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Coordinated_Universal_Time_(UTC))